### PR TITLE
Add workaround to make prospective search work

### DIFF
--- a/nosegae.py
+++ b/nosegae.py
@@ -92,5 +92,18 @@ class NoseGAE(Plugin):
         # required for queue.yaml so the app knows about the task queue names
         self.testbed.init_taskqueue_stub(root_path=self._app_path)
 
+        # workaround to avoid prospective search complain until there is a proper
+        # testbed stub. see http://stackoverflow.com/questions/16026703/testbed-stub-for-google-app-engine-prospective-search
+        from google.appengine.api.prospective_search.prospective_search_stub \
+            import ProspectiveSearchStub
+        PROSPECTIVE_SEARCH_SERVICE_NAME = 'matcher'
+        testbed.SUPPORTED_SERVICES.append(PROSPECTIVE_SEARCH_SERVICE_NAME)
+        ps_data_file = os.path.join(os.path.split(self._data_path)[0],
+                                    'nosegae.ps')
+        ps_stub = ProspectiveSearchStub(
+            prospective_search_path=ps_data_file,
+            taskqueue_stub=self.testbed.get_stub(testbed.TASKQUEUE_SERVICE_NAME))
+        self.testbed._register_stub(PROSPECTIVE_SEARCH_SERVICE_NAME, ps_stub)
+
     def afterTest(self, *args):
         self.testbed.deactivate()


### PR DESCRIPTION
This test will fail with `AssertionError: No api proxy found for service "matcher"` error:

```
from google.appengine.ext import ndb
from google.appengine.ext.ndb import prospective_search

class ProspectiveContract(ndb.Model):
  company_id = ndb.StringProperty()

def test_prospective_match_test(self):
  document_class = ProspectiveContract
  prospective_search.subscribe(document_class, '1', sub_id='1')

  doc = ProspectiveContract(company_id='1')
  prospective_search.match(document=doc,
                           result_relative_url='/queue/prospective_search',
                           result_task_queue='prospective-search')
```

See http://stackoverflow.com/questions/16026703/testbed-stub-for-google-app-engine-prospective-search
Note that even if prospective search match found, the task is not being created for some reason.
I've used the same folder to store prospective search data file where datastore file is stored, you may want to fix this in the next release where you'll add more options.
