### PR TITLE
Re-added code that removes GAE log handler.

### DIFF
--- a/nosegae.py
+++ b/nosegae.py
@@ -107,6 +107,14 @@ class NoseGAE(Plugin):
 
         self.is_doctests = options.enable_plugin_doctest
 
+        # As of SDK 0.2.5 the dev_appserver.py aggressively adds some logging handlers.
+        # This removes the handlers but note that Nose will still capture logging and
+        # report it during failures.  See Issue 25 for more info.
+        rootLogger = logging.getLogger()
+        for handler in rootLogger.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                rootLogger.removeHandler(handler)
+
     def startTest(self, test):
         """Initializes Testbed stubs based off of attributes of the executing test
 


### PR DESCRIPTION
GAE adds a log handler that will output to stdout, which causes all the
logging output during the tests to appear interspersed with the nose
output.  This commit stops that from happening, but does not interfere
with the nose log capturing handler.  The code was initially in commit
7278b8 but seems to have been lost in the rewrite of nosegae.